### PR TITLE
Add validation loss to log

### DIFF
--- a/dp/training/trainer.py
+++ b/dp/training/trainer.py
@@ -102,8 +102,6 @@ class Trainer:
             model.train()
             pbar = tqdm.tqdm(enumerate(train_loader, 1), total=len(train_loader))
             for i, batch in pbar:
-                if i > 10:
-                    continue
                 checkpoint['step'] += 1
                 step = checkpoint['step']
                 self._set_warmup_lr(optimizer=optimizer, step=step,


### PR DESCRIPTION
I think it would be good to also print the validation loss after each epoch to monitor overfitting.
I'm not an expert of tqdm and I wasn't able to change the description bar after the for loop, but I left the code anyway.