### PR TITLE
Downloading and caching checkpoints

### DIFF
--- a/dp/model/model.py
+++ b/dp/model/model.py
@@ -3,6 +3,7 @@ from enum import Enum
 import os
 import requests
 from typing import Tuple, Dict, Any
+from cached_path import cached_path
 import validators
 
 import torch
@@ -295,55 +296,27 @@ def create_model(model_type: ModelType, config: Dict[str, Any]) -> Model:
     return model
 
 
-def load_checkpoint(checkpoint: str, device: str = 'cpu', model_cache_dir: str = 'model_cache') -> Tuple[Model, Dict[str, Any]]:
+def load_checkpoint(checkpoint: str, device: str = 'cpu') -> Tuple[Model, Dict[str, Any]]:
     """
     Initializes a model from a checkpoint (.pt file). If the checkpoint doesn't exist, it is downloaded to a cache.
 
     Args:
         checkpoint (str): Path to checkpoint file (.pt) or name of pre-trained model (.pt) or URL to checkpoint (.pt)
         device (str): Device to put the model to ('cpu' or 'cuda').
-        model_cache_dir (str): Path to model cache (where downloaded checkpoints will be stored to and retrieved from)
 
     Returns: Tuple: The first element is a Model (the loaded model)
              and the second element is a dictionary (config).
     """
 
     device = torch.device(device)
-
     if not checkpoint[-3:] == '.pt':
         raise ValueError(f'{checkpoint} is not a valid model file (.pt).')
-
-    if os.path.exists(checkpoint):
-        # Loading model from given path, not model cache.
-        checkpoint_file_path = checkpoint
-    else:
-        # Loading model from model cache. Download model to cache if necessary.
-        if not os.path.exists(model_cache_dir):
-            os.makedirs(model_cache_dir)
+    if not os.path.exists(checkpoint) and not validators.url(checkpoint):
         model_pt_name = os.path.basename(checkpoint)
-        checkpoint_file_path = f"{model_cache_dir}/{model_pt_name}"
-        if not os.path.exists(checkpoint_file_path):
-            print(f"Downloading {model_pt_name} ...")
-            if validators.url(checkpoint):
-                checkpoint_url = checkpoint
-            else:
-                # Try default model bucket
-                checkpoint_url = f"{DEFAULT_MODEL_BUCKET}/{model_pt_name}"
-            try:
-                response = requests.get(checkpoint_url)
-                response.raise_for_status()
-                with open(checkpoint_file_path, 'wb') as file:
-                    file.write(response.content)
-                print("Download complete.")
-            except requests.exceptions.HTTPError as h_err:
-                raise h_err
-            except requests.exceptions.RequestException as r_exc:
-                raise r_exc
-        else:
-            print(f"{model_pt_name} already exists in cache.")
-
-    print(f"Loading model from {checkpoint_file_path} ...")
-    checkpoint = torch.load(checkpoint_file_path, map_location=device)
+        checkpoint = f"{DEFAULT_MODEL_BUCKET}/{model_pt_name}"
+    checkpoint_path = cached_path(checkpoint)
+    print(f"Loading model from {checkpoint_path} ...")
+    checkpoint = torch.load(checkpoint_path, map_location=device)
     model_type = checkpoint['config']['model']['type']
     model_type = ModelType(model_type)
     model = create_model(model_type, config=checkpoint['config'])

--- a/dp/model/model.py
+++ b/dp/model/model.py
@@ -3,6 +3,7 @@ from enum import Enum
 import os
 import requests
 from typing import Tuple, Dict, Any
+import validators
 
 import torch
 import torch.nn as nn
@@ -298,7 +299,7 @@ def load_checkpoint(checkpoint: str, device: str = 'cpu', model_cache_dir: str =
     Initializes a model from a checkpoint (.pt file). If the checkpoint doesn't exist, it is downloaded to a cache.
 
     Args:
-        checkpoint (str): Path to checkpoint file (.pt) or name of pre-trained model (.pt).
+        checkpoint (str): Path to checkpoint file (.pt) or name of pre-trained model (.pt) or URL to pre-trained model (.pt)
         device (str): Device to put the model to ('cpu' or 'cuda').
 
     Returns: Tuple: The first element is a Model (the loaded model)
@@ -321,7 +322,11 @@ def load_checkpoint(checkpoint: str, device: str = 'cpu', model_cache_dir: str =
         checkpoint_file_path = f"{model_cache_dir}/{model_pt_name}"
         if not os.path.exists(checkpoint_file_path):
             print(f"Downloading {model_pt_name} ...")
-            checkpoint_url = f"{DEFAULT_MODEL_BUCKET}/{model_pt_name}"
+            if validators.url(checkpoint):
+                checkpoint_url = checkpoint
+            else:
+                # Try default model bucket
+                checkpoint_url = f"{DEFAULT_MODEL_BUCKET}/{model_pt_name}"
             try:
                 response = requests.get(checkpoint_url)
                 response.raise_for_status()

--- a/dp/model/model.py
+++ b/dp/model/model.py
@@ -334,9 +334,9 @@ def load_checkpoint(checkpoint: str, device: str = 'cpu', model_cache_dir: str =
                     file.write(response.content)
                 print("Download complete.")
             except requests.exceptions.HTTPError as h_err:
-                print(f"HTTP Error: {h_err}")
+                raise h_err
             except requests.exceptions.RequestException as r_exc:
-                print(f"Request Error: {r_exc}")
+                raise r_exc
         else:
             print(f"{model_pt_name} already exists in cache.")
 

--- a/dp/model/model.py
+++ b/dp/model/model.py
@@ -320,16 +320,22 @@ def load_checkpoint(checkpoint: str, device: str = 'cpu', model_cache_dir: str =
         model_pt_name = os.path.basename(checkpoint)
         checkpoint_file_path = f"{model_cache_dir}/{model_pt_name}"
         if not os.path.exists(checkpoint_file_path):
-            print(f"Downloading {model_pt_name}...")
+            print(f"Downloading {model_pt_name} ...")
             checkpoint_url = f"{DEFAULT_MODEL_BUCKET}/{model_pt_name}"
-            response = requests.get(checkpoint_url)
-            with open(checkpoint_file_path, 'wb') as file:
-                file.write(response.content)
-            print("Download complete.")
+            try:
+                response = requests.get(checkpoint_url)
+                response.raise_for_status()
+                with open(checkpoint_file_path, 'wb') as file:
+                    file.write(response.content)
+                print("Download complete.")
+            except requests.exceptions.HTTPError as h_err:
+                print(f"HTTP Error: {h_err}")
+            except requests.exceptions.RequestException as r_exc:
+                print(f"Request Error: {r_exc}")
         else:
             print(f"{model_pt_name} already exists in cache.")
 
-    print(f"Loading model from {checkpoint_file_path}")
+    print(f"Loading model from {checkpoint_file_path} ...")
     # checkpoint_file_path should contain the .pt file (either already there or just downloaded)
     checkpoint = torch.load(checkpoint_file_path, map_location=device)
     model_type = checkpoint['config']['model']['type']

--- a/dp/model/model.py
+++ b/dp/model/model.py
@@ -11,6 +11,8 @@ from torch.nn import TransformerEncoderLayer, LayerNorm, TransformerEncoder
 from dp.model.utils import get_dedup_tokens, _make_len_mask, _generate_square_subsequent_mask, PositionalEncoding
 from dp.preprocessing.text import Preprocessor
 
+DEFAULT_MODEL_BUCKET = 'https://public-asai-dl-models.s3.eu-central-1.amazonaws.com/DeepPhonemizer'
+
 
 class ModelType(Enum):
     TRANSFORMER = 'transformer'
@@ -303,7 +305,6 @@ def load_checkpoint(checkpoint: str, device: str = 'cpu', model_cache_dir: str =
              and the second element is a dictionary (config).
     """
 
-    default_s3_base_url = 'https://public-asai-dl-models.s3.eu-central-1.amazonaws.com/DeepPhonemizer'
     device = torch.device(device)
 
     if not checkpoint[-3:] == '.pt':
@@ -320,7 +321,7 @@ def load_checkpoint(checkpoint: str, device: str = 'cpu', model_cache_dir: str =
         checkpoint_file_path = f"{model_cache_dir}/{model_pt_name}"
         if not os.path.exists(checkpoint_file_path):
             print(f"Downloading {model_pt_name}...")
-            checkpoint_url = f"{default_s3_base_url}/{model_pt_name}"
+            checkpoint_url = f"{DEFAULT_MODEL_BUCKET}/{model_pt_name}"
             response = requests.get(checkpoint_url)
             with open(checkpoint_file_path, 'wb') as file:
                 file.write(response.content)

--- a/dp/model/model.py
+++ b/dp/model/model.py
@@ -294,13 +294,15 @@ def create_model(model_type: ModelType, config: Dict[str, Any]) -> Model:
                          f'Supported types: {[t.value for t in ModelType]}')
     return model
 
+
 def load_checkpoint(checkpoint: str, device: str = 'cpu', model_cache_dir: str = 'model_cache') -> Tuple[Model, Dict[str, Any]]:
     """
     Initializes a model from a checkpoint (.pt file). If the checkpoint doesn't exist, it is downloaded to a cache.
 
     Args:
-        checkpoint (str): Path to checkpoint file (.pt) or name of pre-trained model (.pt) or URL to pre-trained model (.pt)
+        checkpoint (str): Path to checkpoint file (.pt) or name of pre-trained model (.pt) or URL to checkpoint (.pt)
         device (str): Device to put the model to ('cpu' or 'cuda').
+        model_cache_dir (str): Path to model cache (where downloaded checkpoints will be stored to and retrieved from)
 
     Returns: Tuple: The first element is a Model (the loaded model)
              and the second element is a dictionary (config).
@@ -341,7 +343,6 @@ def load_checkpoint(checkpoint: str, device: str = 'cpu', model_cache_dir: str =
             print(f"{model_pt_name} already exists in cache.")
 
     print(f"Loading model from {checkpoint_file_path} ...")
-    # checkpoint_file_path should contain the .pt file (either already there or just downloaded)
     checkpoint = torch.load(checkpoint_file_path, map_location=device)
     model_type = checkpoint['config']['model']['type']
     model_type = ModelType(model_type)

--- a/dp/phonemizer.py
+++ b/dp/phonemizer.py
@@ -187,19 +187,21 @@ class Phonemizer:
     def from_checkpoint(cls,
                         checkpoint_path: str,
                         device='cpu',
-                        lang_phoneme_dict: Dict[str, Dict[str, str]] = None) -> 'Phonemizer':
+                        lang_phoneme_dict: Dict[str, Dict[str, str]] = None,
+                        model_cache_dir: str = 'model_cache') -> 'Phonemizer':
         """Initializes a Phonemizer object from a model checkpoint (.pt file).
 
         Args:
-          checkpoint_path (str): Path to the .pt checkpoint file.
+          checkpoint_path (str): Path to checkpoint file (.pt), name of pre-trained model (.pt), or checkpoint URL (.pt)
           device (str): Device to send the model to ('cpu' or 'cuda'). (Default value = 'cpu')
           lang_phoneme_dict (Dict[str, Dict[str, str]], optional): Word-phoneme dictionary for each language.
+          model_cache_dir (str): Path to model cache (where downloaded checkpoints will be stored to and retrieved from)
 
         Returns:
           Phonemizer: Phonemizer object carrying the loaded model and, optionally, a phoneme dictionary.
         """
 
-        model, checkpoint = load_checkpoint(checkpoint_path, device=device)
+        model, checkpoint = load_checkpoint(checkpoint_path, device=device, model_cache_dir=model_cache_dir)
         applied_phoneme_dict = None
         if lang_phoneme_dict is not None:
             applied_phoneme_dict = lang_phoneme_dict

--- a/dp/phonemizer.py
+++ b/dp/phonemizer.py
@@ -187,21 +187,19 @@ class Phonemizer:
     def from_checkpoint(cls,
                         checkpoint_path: str,
                         device='cpu',
-                        lang_phoneme_dict: Dict[str, Dict[str, str]] = None,
-                        model_cache_dir: str = 'model_cache') -> 'Phonemizer':
+                        lang_phoneme_dict: Dict[str, Dict[str, str]] = None) -> 'Phonemizer':
         """Initializes a Phonemizer object from a model checkpoint (.pt file).
 
         Args:
           checkpoint_path (str): Path to checkpoint file (.pt), name of pre-trained model (.pt), or checkpoint URL (.pt)
           device (str): Device to send the model to ('cpu' or 'cuda'). (Default value = 'cpu')
           lang_phoneme_dict (Dict[str, Dict[str, str]], optional): Word-phoneme dictionary for each language.
-          model_cache_dir (str): Path to model cache (where downloaded checkpoints will be stored to and retrieved from)
 
         Returns:
           Phonemizer: Phonemizer object carrying the loaded model and, optionally, a phoneme dictionary.
         """
 
-        model, checkpoint = load_checkpoint(checkpoint_path, device=device, model_cache_dir=model_cache_dir)
+        model, checkpoint = load_checkpoint(checkpoint_path, device=device)
         applied_phoneme_dict = None
         if lang_phoneme_dict is not None:
             applied_phoneme_dict = lang_phoneme_dict

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ tensorboard
 certifi>=2022.12.7
 wheel>=0.38.0
 setuptools>=65.5.1
+validators==0.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ certifi>=2022.12.7
 wheel>=0.38.0
 setuptools>=65.5.1
 validators>=0.22.0
+cached-path>=1.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ tensorboard
 certifi>=2022.12.7
 wheel>=0.38.0
 setuptools>=65.5.1
-validators==0.22.0
+validators>=0.22.0

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ setup(
     long_description_content_type='text/x-rst',
     license='MIT',
     install_requires=['torch>=1.2.0', 'tqdm>=4.38.0', 'PyYAML>=5.1', 'tensorboard',
-                      'certifi>=2022.12.7', 'wheel>=0.38.0', 'setuptools>=65.5.1', 'validators>=0.22.0'],
+                      'certifi>=2022.12.7', 'wheel>=0.38.0', 'setuptools>=65.5.1',
+                      'cached-path>=1.5.0', 'validators>=0.22.0'],
     extras_require={
         'tests': ['pytest-cov'],
         'docs': ['mkdocs', 'mkdocs-material'],

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     long_description_content_type='text/x-rst',
     license='MIT',
     install_requires=['torch>=1.2.0', 'tqdm>=4.38.0', 'PyYAML>=5.1', 'tensorboard',
-                      'certifi>=2022.12.7', 'wheel>=0.38.0', 'setuptools>=65.5.1'],
+                      'certifi>=2022.12.7', 'wheel>=0.38.0', 'setuptools>=65.5.1', 'validators>=0.22.0'],
     extras_require={
         'tests': ['pytest-cov'],
         'docs': ['mkdocs', 'mkdocs-material'],


### PR DESCRIPTION
Downloading and caching ability when loading checkpoints (similar to Transformers API).
- Can now provide a checkpoint filename or a checkpoint URL (or just a file path as before). Regardless, value passed  to `checkpoint_path` in `Phonemizer.from_checkpoint()` should end with `.pt`. See test results below.
- If just a checkpoint name is provided, it will try to retrieve the checkpoint under the `DEFAULT_MODEL_BUCKET` (see `dp/model/model.py`).
- Caching is facilitated with [cached_path](https://github.com/allenai/cached_path)

## Why?
- Convenient checkpoint loading (familiar behavior to what we're used to with Transformers/HuggingFace). 
- No longer have to manage location of checkpoints.
- Enables easier model fetching (if your own trained checkpoints are on S3, MinIO, etc.) 

## Test cases:

#### Invalid file
```
>>> phonemizer = Phonemizer.from_checkpoint('test')
ValueError: test is not a valid model file (.pt).
```

#### Invalid checkpoint file
```
>>> phonemizer = Phonemizer.from_checkpoint('test.pt')
...
requests.exceptions.HTTPError: 403 Client Error: Forbidden for url: https://public-asai-dl-models.s3.eu-central-1.amazonaws.com/DeepPhonemizer/test.pt
```

#### Checkpoint name provided
```
>>> phonemizer = Phonemizer.from_checkpoint('en_us_cmudict_forward.pt')
Loading model from /PATH/TO/.cache/cached_path/6c84425c...
>>>
```

#### Cached model loaded
```
>>> phonemizer = Phonemizer.from_checkpoint('en_us_cmudict_forward.pt')
Loading model from /PATH/TO/.cache/cached_path/6c84425c...
>>>
```

#### URL to checkpoint provided
```
>>> phonemizer = Phonemizer.from_checkpoint('https://public-asai-dl-models.s3.eu-central-1.amazonaws.com/DeepPhonemizer/en_us_cmudict_ipa_forward.pt')
Loading model from /PATH/TO/.cache/cached_path/3f662135...
>>>
```

#### Cached model loaded (with just checkpoint name)
```
>>> phonemizer = Phonemizer.from_checkpoint('en_us_cmudict_ipa_forward.pt')
en_us_cmudict_ipa_forward.pt already exists in cache.
Loading model from /PATH/TO/.cache/cached_path/3f662135...
>>>
```

#### Cached model loaded (with checkpoint URL)
```
>>> phonemizer = Phonemizer.from_checkpoint('https://public-asai-dl-models.s3.eu-central-1.amazonaws.com/DeepPhonemizer/en_us_cmudict_ipa_forward.pt')
en_us_cmudict_ipa_forward.pt already exists in cache.
Loading model from /PATH/TO/.cache/cached_path/3f662135...
>>>
```